### PR TITLE
File uploads to match Starlette documentation

### DIFF
--- a/examples/dynamic_user_interface_(htmx)/multi_image_upload/app.py
+++ b/examples/dynamic_user_interface_(htmx)/multi_image_upload/app.py
@@ -30,11 +30,7 @@ async def ImageCard(image):
     return Card(H4(image.filename), Img(src=img_data, alt=image.filename))
 
 @rt
-async def upload(request: Request):
-    # get all results from the request
-    form = await request.form()
-    # Get the images in a list
-    images = form.getlist("images")
+async def upload(images: list[UploadFile]):
     # Create a grid filled with 1 image card per image
     return Grid(*[await ImageCard(image) for image in images])
 


### PR DESCRIPTION
Multiple file uploads didn't used to work very well at the time the blog post was written. We've addressed that in core, and now file uploads based on the current status quo of how FastHTML handlers can now use `list[FileUpload]` types per the Starlette documentation. 

> [!NOTE]  
> If there is a desire to implement file uploads in both this method and the one mention in the blog post I can break this out to a separate file.